### PR TITLE
fix: ArrayShape Attribute used wrong apostrophe and namespace fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Use Array Shape when you deal with object-like arrays and want to specify the ke
 
 ```PHP
 #[ArrayShape([
- // ‘key’ => ’type’,
-    ‘key1’ => ‘int’,
-    ‘key2’ => ‘string’,
-    ‘key3’ => ‘Foo’,
-    ‘key3’ => App\PHP 8\Foo::class,
+ // 'key' => 'type',
+    'key1' => 'int',
+    'key2' => 'string',
+    'key3' => 'Foo',
+    'key3' => App\PHP8\Foo::class,
 ])]
 function functionName(...): array
 ```


### PR DESCRIPTION
This commit fixes the ArrayShape Attribute example since it used syntax that is incorrect (‘) and it updated the namespace `App\PHP 8\Foo::class` to `App\PHP8\Foo::class`, like the example because namespaces can not have any spaces anyways.