### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/ExpectedValues.php
+++ b/src/ExpectedValues.php
@@ -37,7 +37,7 @@ use Attribute;
  */
 #[Attribute(Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class ExpectedValues {
-    public function __construct(array $values = [], array $flags = [], string $valuesFromClass = null, string $flagsFromClass = null)
+    public function __construct(array $values = [], array $flags = [], ?string $valuesFromClass = null, ?string $flagsFromClass = null)
     {
     }
 }


### PR DESCRIPTION
Fixes for https://php.watch/rfcs/deprecate-implicitly-nullable-types