### PR TITLE
fix wrong Deprecated attribute docblock

### DIFF
--- a/src/Deprecated.php
+++ b/src/Deprecated.php
@@ -34,7 +34,7 @@ class Deprecated {
      * <li>%class%: If the attribute is provided for method "m", then for "$this->f()->m()", %class% will be "$this->f()"</li>
      * </ul>
      * The following example shows how to wrap a function call in another call and swap arguments:<br />
-     * "#[Deprecated(replaceWith: "wrappedCall(%name%(%parameter1%, %parameter0%))")] f($a, $b){}<br />
+     * "#[Deprecated(replacement: "wrappedCall(%name%(%parameter1%, %parameter0%))")] f($a, $b){}<br />
      * f(1,2) will be replaced with wrappedCall(f(2,1))
      * @param string $since Element is deprecated starting with the provided PHP language level, applicable only for PhpStorm stubs entries
      */


### PR DESCRIPTION
Fixes the wrong named parameter in the `#[Deprecated]` docblock.

The correct parameter name is `replacement`, not `replaceWith`.